### PR TITLE
[Memory Leak] Removes the selectionMode feature to fix the memory leak

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -195,7 +195,6 @@ StyleBindingsMixin, ResizeHandlerMixin, {
       return rowClass.create({
         content: datum,
         itemIndex: index,
-        tableComponent: self
       });
     });
   }),

--- a/addon/models/row.js
+++ b/addon/models/row.js
@@ -2,18 +2,6 @@ import Ember from 'ember';
 
 export default Ember.ObjectProxy.extend({
   content: null,
-  tableComponent: null,
-
   isShowing: true,
   isHovered: false,
-
-  isSelected: Ember.computed('tableComponent.selection.[]', {
-    set: function(key, val) {
-      this.get('tableComponent').setSelected(this, val);
-      return this.get('tableComponent').isSelected(this);
-    },
-    get: function() {
-    	return this.get('tableComponent').isSelected(this);
-    }
-  })
 });


### PR DESCRIPTION
Removes the `selectionMode` feature to fix serious memory leak. Fortunately, TG core doesn't use this feature