### PR TITLE
[Memory Leak] Fix exposing the entire component as controller to the …

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -231,7 +231,6 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   prepareTableColumns: function() {
     var _this = this;
     var columns = this.get('columns') || Ember.A();
-    columns.setEach('controller', this);
     columns.forEach(function(col, i) {
       col.set('nextResizableColumn', _this.getNextResizableColumn(columns, i));
     });


### PR DESCRIPTION
Currently, the column definitions holds a reference to the ember table component & since the column definitions reside in controllers, those references leaks the table component even after they are destroyed.

Fixes exposing the entire component as `controller` in the columns array. 

