### PR TITLE
[BUGFIX] Resizable columns with min/max Widths

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -391,7 +391,7 @@ const ColumnTreeNode = EmberObject.extend({
       delta = Math.max(Math.min(oldWidth + delta, maxWidth), minWidth) - oldWidth;
 
       if (delta === 0) {
-        return;
+        return oldWidth;
       }
 
       if (get(this, 'isLeaf')) {


### PR DESCRIPTION
#### Summary
Resizable columns with a min or max widths broke the table. This is because `column-tree.js:434` hit this codepath and as a result the width got set to `undefined`. After that the resizing logic could not recover because of `NaN` errors and got stuck in an infinite loop resulting in a `loop count exceeded guard while distributing width`.

#### Note
This may be a bug in the main fork as well, but I havn't tested it.