### PR TITLE
Added missing gt to isMultiSort

### DIFF
--- a/addon/-private/column-tree.js
+++ b/addon/-private/column-tree.js
@@ -137,7 +137,7 @@ const TableColumnMeta = EmberObject.extend({
 
   isSorted: gt('sortIndex', 0),
 
-  isMultiSorted: ('_node.tree.sorts.length', 1),
+  isMultiSorted: gt('_node.tree.sorts.length', 1),
 
   isSortedAsc: computed('_node.tree.sorts.[]', 'sortIndex', {
     get() {


### PR DESCRIPTION
#### Summary

`isMultiSort` was missing the `gt` part. I imagine this happened when we de-decorated the class.

Here is the equivalent code in `master` of ember-table >>
https://github.com/Addepar/ember-table/blob/master/addon/-private/column-tree.js#L145


#### Motivation
I need this to add the sort functionality to our table.
