### PR TITLE
Backport custom container selector which is required for occluding ta…

### DIFF
--- a/addon/components/ember-tbody/component.js
+++ b/addon/components/ember-tbody/component.js
@@ -91,6 +91,8 @@ export default Component.extend({
   // @type(optional(Action))
   // onSelect = null;
 
+  containerSelector: computedFallbackIfUndefined('.ember-table'),
+
   /**
     Estimated height for each row. This number is used to decide how many rows
     will be rendered at initial rendering.

--- a/addon/components/ember-tbody/template.hbs
+++ b/addon/components/ember-tbody/template.hbs
@@ -1,5 +1,5 @@
 {{#vertical-collection wrappedRows
-  containerSelector=".ember-table"
+  containerSelector=containerSelector
 
   estimateHeight=estimateRowHeight
   key=key


### PR DESCRIPTION
Backports custom container selector which is required for occluding tables that don't have fixed height.

https://github.com/Addepar/ember-table/pull/619